### PR TITLE
Fix email bug in validation with specific a specific key

### DIFF
--- a/ionwizard/validate.py
+++ b/ionwizard/validate.py
@@ -71,8 +71,8 @@ def license_check(library_name, custom_library_key=None, check_machine_id=True):
 
     # Data to send in the POST request
     data = {"meta": {"key": library_key}}
-
-    data = add_email_to(data)
+    if custom_library_key is None:
+        data = add_email_to(data)
 
     # Send the POST request
     response = requests.post(url, headers=headers, json=data)


### PR DESCRIPTION
Fixes an issue when a license key does not have an email attached. There may be other cases when things like this crop up, but this fixes one of the issues.