### PR TITLE
Update installation tool

### DIFF
--- a/Quick_start/project_installation.md
+++ b/Quick_start/project_installation.md
@@ -5,23 +5,34 @@ file. The project wizard does the following:
 1. Read the `pyproject.toml`
 2. Look for the ionworks license key stored on your machine
 3. Install ionworks libraries from the private repositories
-4. Install the remaining dependencies and project metadata for the project in
-   editable mode
+4. Install the remaining dependencies and project metadata for the project
 
 ## Install with a explicit configuration file
 
 If a library [configuration file](library_installation.md) was provided,
 then the configuration file can be passed into the installer:
 ```bash
-ionwizard-install <your_config_file>.yml
+ionwizard-install -c <your_config_file>.yml
 ```
 This will read the configuration file and store the license key information
 locally so that it can be reused by ionworks applications.
 
 ## Install using a saved configuration
 
-If a ionworks configurate file is already stored locally, then the install
+If a ionworks configuration file is already stored locally, then the install
 tool can be run without any arguments:
 ```bash
 ionwizard-install
 ```
+
+## Additional pip arguments
+
+Other than the configuration file, all arguments are forwarded to `pip` while
+installing the package. For example, to install the dev dependencies in 
+editable mode:
+```bash
+ionwizard-install -c <your_config_file>.yml -e ".[dev]"
+```
+This command will read the config file, install the ionworks packages,
+save the ionworks configuration file, then install the rest of the project in
+editable mode with the dev dependencies.

--- a/ionwizard/install_project.py
+++ b/ionwizard/install_project.py
@@ -1,7 +1,7 @@
-import sys
+import argparse
 import copy
-import subprocess
 import toml
+import subprocess
 from ionwizard.validate import read_config_libraries
 from ionwizard.library_wizard import IonWorksPipWizard
 import tempfile
@@ -14,12 +14,10 @@ class IonWorksInstallWizard(IonWorksPipWizard):
     dependencies separately.
     """
 
-    def collect_libraries_to_install(self):
-        if len(sys.argv) > 1:
-            if ".yml" in sys.argv[1]:
-                config_file = sys.argv[1]
-                processed_config = self.process_config(config_file)
-                self.save_config(processed_config)
+    def collect_libraries_to_install(self, config_name: str | None = None):
+        if config_name:
+            processed_config = self.process_config(config_name)
+            self.save_config(processed_config)
         libraries = read_config_libraries()
         return libraries
 
@@ -50,25 +48,30 @@ class IonWorksInstallWizard(IonWorksPipWizard):
         return pyproject_file
 
     @staticmethod
-    def install_from_pyproject(pyproject_file):
+    def install_from_pyproject(pyproject_file, pip_arguments):
+        if not pip_arguments:
+            pip_arguments = ["."]
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_config = Path(temp_dir) / "pyproject.toml"
             with open(temp_config, "w") as f:
                 toml.dump(pyproject_file, f)
-            cmd = [
-                "pip",
-                "install",
-                "-e",
-                ".",
-                f"--config-settings=pyproject_toml={temp_config}",
-            ]
+            cmd = (
+                ["pip", "install"]
+                + pip_arguments
+                + [f"--config-settings=pyproject_toml={temp_config}"]
+            )
             subprocess.run(cmd)
 
 
 def run():
-    libraries = IonWorksInstallWizard().collect_libraries_to_install()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", type=str, required=False)
+    config_args, pip_args = parser.parse_known_args()
+    config_name = config_args.c
+
+    libraries = IonWorksInstallWizard().collect_libraries_to_install(config_name)
     new_pyproject = IonWorksInstallWizard().install_libraries_from_config(libraries)
-    IonWorksInstallWizard.install_from_pyproject(new_pyproject)
+    IonWorksInstallWizard.install_from_pyproject(new_pyproject, pip_args)
 
 
 if __name__ == "__main__":

--- a/ionwizard/install_project.py
+++ b/ionwizard/install_project.py
@@ -1,6 +1,6 @@
-import argparse
 import copy
 import toml
+import argparse
 import subprocess
 from ionwizard.validate import read_config_libraries
 from ionwizard.library_wizard import IonWorksPipWizard


### PR DESCRIPTION
I added some argument parsing to let the following command work:
```bash
ionwizard-install -c <your_config_file>.yml -e ".[dev]"
```
This does change some of the documentation and usage for the installer, but it will make ionwizard easier to use in existing workflows.